### PR TITLE
spec file modification

### DIFF
--- a/setiastrosuitemac.spec
+++ b/setiastrosuitemac.spec
@@ -5,7 +5,7 @@ a = Analysis(
     pathex=[],
     binaries=[],
     datas=[
-        ('.venv/lib/python3.12/site-packages/astroquery/CITATION', 'astroquery'),
+        ('.venv/lib/python3.*/site-packages/astroquery/CITATION', 'astroquery'),
         ('celestial_catalog.csv', '.'), 
         ('astrosuite.png', '.'), 
         ('wimilogo.png', '.'), 
@@ -54,8 +54,8 @@ a = Analysis(
         ('font.png', '.'), 
         ('spinner.gif', '.'), 
         ('cvs.png', '.'), 
-        ('.venv/lib/python3.12/site-packages/astroquery/simbad/data', 'astroquery/simbad/data'), 
-        ('.venv/lib/python3.12/site-packages/astropy/CITATION', 'astropy')
+        ('.venv/lib/python3.*/site-packages/astroquery/simbad/data', 'astroquery/simbad/data'), 
+        ('.venv/lib/python3.*/site-packages/astropy/CITATION', 'astropy')
     ],
     hiddenimports=[],
     hookspath=[],

--- a/setiastrosuitemac.spec
+++ b/setiastrosuitemac.spec
@@ -1,11 +1,13 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+site_packages = '.venv/lib/python3.*/site-packages'
+
 a = Analysis(
     ['setiastrosuitemacQT6.py'],
     pathex=[],
     binaries=[],
     datas=[
-        ('.venv/lib/python3.*/site-packages/astroquery/CITATION', 'astroquery'),
+        (site_packages + '/astroquery/CITATION', 'astroquery'),
         ('celestial_catalog.csv', '.'), 
         ('astrosuite.png', '.'), 
         ('wimilogo.png', '.'), 
@@ -54,8 +56,8 @@ a = Analysis(
         ('font.png', '.'), 
         ('spinner.gif', '.'), 
         ('cvs.png', '.'), 
-        ('.venv/lib/python3.*/site-packages/astroquery/simbad/data', 'astroquery/simbad/data'), 
-        ('.venv/lib/python3.*/site-packages/astropy/CITATION', 'astropy')
+        (site_packages + '/astroquery/simbad/data', 'astroquery/simbad/data'), 
+        (site_packages + '/astropy/CITATION', 'astropy')
     ],
     hiddenimports=[],
     hookspath=[],


### PR DESCRIPTION
Simplify the existing local paths to allow a more global redirection if someone wants to manually add their own, otherwise, use one that uses the locally added resources in the created .venv folder. The wild-carding of the python version also allows the user to specify different python3 versions. Tested with python 3.12 and 3.13.